### PR TITLE
add hfsplus ro mount, more verbose logging, and typo

### DIFF
--- a/media-automount
+++ b/media-automount
@@ -83,7 +83,7 @@ fi
 AUTOMOUNT_DIR="${mediadir}/${LABEL:-${dev##*/}}.$TYPE"
 
 # Load Filesystem-specific configuration for mounting
-if [ -e "%confdir/$TYPE" ]
+if [ -e "$confdir/$TYPE" ]
 then
 	source "$confdir/$TYPE"
 elif [ -e "$confdir/auto" ]

--- a/media-automount
+++ b/media-automount
@@ -42,6 +42,7 @@ then
         else
             exitcode=$?
             log "Error umounting $dev errcode:$exitcode"
+            log "Command was: umount $dev"
         fi
     else
         # prevent it from failing on nonexistent devices and degrading systemctl boot
@@ -85,6 +86,7 @@ AUTOMOUNT_DIR="${mediadir}/${LABEL:-${dev##*/}}.$TYPE"
 # Load Filesystem-specific configuration for mounting
 if [ -e "$confdir/$TYPE" ]
 then
+        log "loading configuration for fs type $TYPE"
 	source "$confdir/$TYPE"
 elif [ -e "$confdir/auto" ]
 then
@@ -102,6 +104,8 @@ then
     exit 0
 else
     log "Mount error: $?"
+    log "Command was : mount -t $AUTOMOUNT_TYPE -o $AUTOMOUNT_OPTS $dev $AUTOMOUNT_DIR"
+
     rmdir "$AUTOMOUNT_DIR"
     exit 1
 fi

--- a/media-automount.d/hfsplus
+++ b/media-automount.d/hfsplus
@@ -1,0 +1,5 @@
+# -*- sh -*-
+
+# Options to use for auto-mounting devices detected with an hfsplus filesystem 
+AUTOMOUNT_OPTS=ro,relatime
+


### PR DESCRIPTION
Hello ! I'm proposing the tweaks I made for this nice script to work on my small server with hfsplus filesystems, mountable as read-only under linux ATM. First I added log messages in case of mount error to show the mount command issued. Then I noticed there was a typo in the inclusion of `media-automount.d` files. And at last I added mount options so hfsplus filesystems do get mounted. Feel free to pick some of the 3 commits I made - I just wish I'll notice it when you're done, because I use the PKGBUILD for this script in my server's system annd would update it accordingly.