### PR TITLE
Replace " with ' to handle " " (space) character in partition labels

### DIFF
--- a/media-automount
+++ b/media-automount
@@ -56,7 +56,7 @@ then
     for dir in "$mediadir"/*
     do
         # Only clean non active mountpoints that have no /etc/fstab entry
-        if [ -d "$dir" ] && ! mountpoint -q "$dir" && awk '$2=="'$dir'"{exit 1}' /etc/fstab; then
+        if [ -d "$dir" ] && ! mountpoint -q "$dir" && awk '$2==''$dir''{exit 1}' /etc/fstab; then
             rmdir "$dir"
         fi
     done


### PR DESCRIPTION
When automounting an exFAT Disk with a space in the partition label, a duplicate mount was created because the space in the awk command was not escaped.
By using '' instead of "", the space is escaped properly and only one mount point is created for the affected partition/thumb drive.