### PR TITLE
Support more devices

### DIFF
--- a/media-automount.rules
+++ b/media-automount.rules
@@ -8,8 +8,18 @@
 # mounting has to be done as a separate "service"
 
 # mount the device when added
+# Physical SATA, SCSI, and USB
 KERNEL=="sd[a-z]*", ACTION=="add",  	RUN+="/usr/bin/systemctl --no-block restart media-automount@%k.service"
+# Virtual SATA, SCSI, and USB
+KERNEL=="vd[a-z]*", ACTION=="add",  	RUN+="/usr/bin/systemctl --no-block restart media-automount@%k.service"
+# eMMC and SD cards
+KERNEL=="mmcblk[0-9]p[0-9]", ACTION=="add",  	RUN+="/usr/bin/systemctl --no-block restart media-automount@%k.service"
+# NVMe
+KERNEL=="nvme[0-9]n[0-9]p[0-9]", ACTION=="add",  	RUN+="/usr/bin/systemctl --no-block restart media-automount@%k.service"
 
 # clean up after device removal
 KERNEL=="sd[a-z]*", ACTION=="remove",	RUN+="/usr/bin/systemctl --no-block restart media-automount@%k.service"
+KERNEL=="vd[a-z]*", ACTION=="remove",	RUN+="/usr/bin/systemctl --no-block restart media-automount@%k.service"
+KERNEL=="mmcblk[0-9]p[0-9]", ACTION=="remove",	RUN+="/usr/bin/systemctl --no-block restart media-automount@%k.service"
+KERNEL=="nvme[0-9]n[0-9]p[0-9]", ACTION=="remove",	RUN+="/usr/bin/systemctl --no-block restart media-automount@%k.service"
 


### PR DESCRIPTION
by adding udev rules to checking for virtual SATA/SCSI/USB devices, eMMC and SD cards, and NVMe drives.