### PR TITLE
fix: UUID/LABEL check in /etc/fstab

### DIFF
--- a/media-automount
+++ b/media-automount
@@ -74,8 +74,8 @@ then
 fi
 
 # Check /etc/fstab for an entry corresponding to the device
-[ "$UUID" ] && fstab=$(grep /etc/fstab -e "^[^#]*${UUID}") || \
-[ "$LABEL" ] && fstab=$(grep /etc/fstab -e "^[^#]*${LABEL}") || \
+[ "$UUID" ] && fstab=$(grep /etc/fstab -e "^[^#]*UUID=${UUID}") || \
+[ "$LABEL" ] && fstab=$(grep /etc/fstab -e "^[^#]*LABEL=${LABEL}") || \
 fstab=$(grep /etc/fstab -e "^[ \t]*$dev[ \t]")
 
 # Don't manage devices that are already in fstab


### PR DESCRIPTION
Make the UUID/LABEL check more specific.
The existing code considers the device already managed by fstab if *any* non-commented line contains either UUID or LABEL somewhere.

E.g. if I have a partition with LABEL=foobar and a line in /etc/fstab such as
```
/dev/sda1 /mnt/foobar ext4 defaults 0 2
```
then `media-automount` script will abort and not manage the device.

This patch explicitly looks for e.g. `LABEL=foobar` defined in the fstab. Same for UUID.