### PR TITLE
Do only look for LABEL in the first column of fstab

### DIFF
--- a/media-automount
+++ b/media-automount
@@ -75,7 +75,7 @@ fi
 
 # Check /etc/fstab for an entry corresponding to the device
 [ "$UUID" ] && fstab=$(grep /etc/fstab -e "^[^#]*${UUID}") || \
-[ "$LABEL" ] && fstab=$(grep /etc/fstab -e "^[^#]*${LABEL}") || \
+[ "$LABEL" ] && fstab=$(grep /etc/fstab -e "^[^# ]*${LABEL}") || \
 fstab=$(grep /etc/fstab -e "^[ \t]*$dev[ \t]")
 
 # Don't manage devices that are already in fstab


### PR DESCRIPTION
Do not allow spaces if matching LABEL in order to ignore mount point and other fstab line content.

fixes #25